### PR TITLE
docs: add agile program management guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,4 +216,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ---
 
-For detailed implementation guidance, please refer to the [Implementation Guide](./implementation-guide.md).
+## Additional Documentation
+
+- [Implementation Guide](./commercial-ratio-analyzer-documentation.md)
+- [Agile Program Management Guide](./agile-program-management.md)

--- a/agile-program-management.md
+++ b/agile-program-management.md
@@ -1,0 +1,54 @@
+# Agile Program Management Guide
+
+## Overview
+The Commercial Ratio Analyzer is a React component that evaluates sales and marketing efficiency by modeling how changes in the Commercial Ratio affect revenue and costs. It manages core financial inputs, user controls, and calculated metrics with React hooks, allowing teams to explore the impact of different go‑to‑market strategies in real time.
+
+## Source Code Structure
+The application is implemented in a single TypeScript file, `commercial-ratio-analyzer.tsx`, which organizes state and calculations for financial data, Commercial Ratio adjustments, and derived metrics. Initial financial values and core state are defined at the top of the file, and calculation effects update results when inputs change.
+
+### Key Sections
+- **Initial State Management** – financial metrics, Commercial Ratio, impact type, tab selection, and calculated values
+- **Calculation Effects** – compute expenses, EBITDA, market capitalization, and scenario impacts
+- **User Interface** – renders controls, tab navigation, and detailed metric tables
+
+## Agile Development Approach
+
+### Roles
+- **Product Owner** – defines business objectives and prioritizes the backlog
+- **Scrum Master** – facilitates ceremonies and removes impediments
+- **Development Team** – implements features, tests, and documentation
+
+### Ceremonies
+1. **Sprint Planning** – select user stories from the prioritized backlog and define acceptance criteria
+2. **Daily Stand‑ups** – share progress, plans, and blockers
+3. **Sprint Review** – demonstrate increment, gather stakeholder feedback
+4. **Sprint Retrospective** – inspect process and define improvements
+
+### Artifacts
+- **Product Vision** – deliver an interactive tool that quantifies how CR adjustments influence financial performance
+- **Product Backlog** – epics for data integration, visualization enhancements, and reporting
+- **Sprint Backlog** – granular user stories with estimates and definition of done
+- **Increment** – validated code, updated documentation, and working demos each sprint
+
+### Workflow
+1. Refine backlog items with the Product Owner
+2. Implement code and tests in short iterations
+3. Maintain documentation alongside source changes
+4. Review pull requests for quality and adherence to standards
+5. Release incremental updates at the end of each sprint
+
+### Definition of Done
+- Code committed and reviewed
+- Tests pass and TypeScript builds without errors
+- Documentation updated
+- Feature demonstrated in sprint review
+
+## Getting Started for Contributors
+1. Read the main [README](./README.md) and the [Implementation Guide](./commercial-ratio-analyzer-documentation.md)
+2. Set up a development environment with React and TypeScript
+3. Use `npx tsc` to verify TypeScript types before committing
+4. Open issues for new features or bugs and reference user stories
+5. Submit pull requests tied to backlog items
+
+## References
+- [Commercial Ratio Analyzer Implementation Guide](./commercial-ratio-analyzer-documentation.md)


### PR DESCRIPTION
## Summary
- add Agile Program Management Guide outlining roles, ceremonies, and workflow for the Commercial Ratio Analyzer
- link README to both the Implementation Guide and new program management documentation

## Testing
- `npx tsc --noEmit commercial-ratio-analyzer.tsx` *(fails: Cannot find module 'react' and JSX flag)*

------
https://chatgpt.com/codex/tasks/task_e_68935964ee488320802471cb9669e000